### PR TITLE
updated to .net 4.5.2 and added tls 1.2

### DIFF
--- a/src/TeleSign.Services.PhoneId/TeleSign.Services.PhoneId.csproj
+++ b/src/TeleSign.Services.PhoneId/TeleSign.Services.PhoneId.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TeleSign.Services.PhoneId</RootNamespace>
     <AssemblyName>TeleSign.Services.PhoneId</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\TeleSign.Services.PhoneId.XML</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">

--- a/src/TeleSign.Services.Verify/RawVerifyService.cs
+++ b/src/TeleSign.Services.Verify/RawVerifyService.cs
@@ -52,7 +52,7 @@ namespace TeleSign.Services.Verify
         /// <param name="configuration">The configuration information for the service.</param>
         /// <param name="webRequester">The web requester to use.</param>
         public RawVerifyService(
-                    TeleSignServiceConfiguration configuration, 
+                    TeleSignServiceConfiguration configuration,
                     IWebRequester webRequester)
             : base(configuration, webRequester)
         {
@@ -79,7 +79,7 @@ namespace TeleSign.Services.Verify
                     string phoneNumber,
                     string verifyCode = null,
                     string messageTemplate = null,
-                    string language = null)
+                    string language = null, string senderID = null)
         {
             phoneNumber = this.CleanupPhoneNumber(phoneNumber);
 
@@ -88,7 +88,7 @@ namespace TeleSign.Services.Verify
                         phoneNumber,
                         verifyCode,
                         messageTemplate,
-                        language);
+                        language, senderID);
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace TeleSign.Services.Verify
                         null,
                         language);
         }
-        
+
         /////// <summary>
         /////// The TeleSign Verify Soft Token web service is a server-side component of the TeleSign AuthID application, and it allows you to authenticate your end users when they use the TeleSign AuthID application on their mobile device to generate a Time-based One-time Password (TOTP) verification code
         /////// </summary>
@@ -137,12 +137,12 @@ namespace TeleSign.Services.Verify
         ////            string verifyCode = null)
         ////{
         ////    phoneNumber = this.CleanupPhoneNumber(phoneNumber);
-            
+
         ////    if (softTokenId == null)
         ////    {
         ////        softTokenId = string.Empty;
         ////    }
-            
+
         ////    if (verifyCode == null)
         ////    {
         ////        verifyCode = string.Empty;
@@ -165,7 +165,7 @@ namespace TeleSign.Services.Verify
 
         ////    return this.WebRequester.ReadResponseAsString(request);
         ////}
-        
+
         /// <summary>
         /// The TeleSign Verify 2-Way SMS web service allows you to authenticate your users and verify user transactions via two-way Short Message Service (SMS) wireless communication. Verification requests are sent to user’s in a text message, and users return their verification responses by replying to the text message.
         /// </summary>
@@ -183,7 +183,7 @@ namespace TeleSign.Services.Verify
         public string TwoWaySmsRaw(
                     string phoneNumber,
                     string message,
-            		string validityPeriod = "5m",
+                    string validityPeriod = "5m",
                     string useCaseId = RawVerifyService.DefaultUseCaseId)
         {
             CheckArgument.NotEmpty(message, "message");
@@ -193,15 +193,15 @@ namespace TeleSign.Services.Verify
 
             Dictionary<string, string> args = ConstructVerifyArgs(
                         VerificationMethod.TwoWaySms,
-                		phoneNumber,
-                		null,
+                        phoneNumber,
+                        null,
                         message,
                         null,
                         validityPeriod,
                         useCaseId);
 
             string resourceName = string.Format(
-                        RawVerifyService.VerifyResourceFormatString, 
+                        RawVerifyService.VerifyResourceFormatString,
                         "two_way_sms");
 
             WebRequest request = this.ConstructWebRequest(
@@ -268,7 +268,7 @@ namespace TeleSign.Services.Verify
             }
 
             string resourceName = string.Format(
-                        RawVerifyService.VerifyResourceFormatString, 
+                        RawVerifyService.VerifyResourceFormatString,
                         referenceId);
 
             WebRequest request = this.ConstructWebRequest(
@@ -301,7 +301,7 @@ namespace TeleSign.Services.Verify
                     string phoneNumber,
                     string verifyCode = null,
                     string messageTemplate = null,
-                    string language = null)
+                    string language = null, string senderID = null)
         {
             this.CleanupPhoneNumber(phoneNumber);
 
@@ -316,14 +316,14 @@ namespace TeleSign.Services.Verify
             }
 
             Dictionary<string, string> args = ConstructVerifyArgs(
-                        verificationMethod, 
-                        phoneNumber, 
-                        verifyCode, 
-                        messageTemplate, 
-                        language);
+                        verificationMethod,
+                        phoneNumber,
+                        verifyCode,
+                        messageTemplate,
+                        language, senderID: senderID);
 
             string resourceName = string.Format(
-                        RawVerifyService.VerifyResourceFormatString, 
+                        RawVerifyService.VerifyResourceFormatString,
                         verificationMethod.ToString().ToLowerInvariant());
 
             WebRequest request = this.ConstructWebRequest(
@@ -344,13 +344,14 @@ namespace TeleSign.Services.Verify
         /// <param name="language">The language for the message. Ignored for SMS when a template is provided.</param>
         /// <returns>A dictionary of arguments for a Verify transaction.</returns>
         private static Dictionary<string, string> ConstructVerifyArgs(
-                    VerificationMethod verificationMethod, 
-                    string phoneNumber, 
-                    string verifyCode, 
-                    string messageTemplate, 
+                    VerificationMethod verificationMethod,
+                    string phoneNumber,
+                    string verifyCode,
+                    string messageTemplate,
                     string language,
                     string validityPeriod = null,
-                    string useCaseId = RawVerifyService.DefaultUseCaseId)
+                    string useCaseId = RawVerifyService.DefaultUseCaseId,
+                    string senderID = null)
         {
             // TODO: Review code generation rules.
             if (verifyCode == null)
@@ -390,6 +391,11 @@ namespace TeleSign.Services.Verify
             if (!string.IsNullOrEmpty(language))
             {
                 args.Add("language", language);
+            }
+
+            if (!string.IsNullOrEmpty(senderID))
+            {
+                args.Add("sender_id", senderID);
             }
 
             if (verificationMethod == VerificationMethod.Sms || verificationMethod == VerificationMethod.Push)

--- a/src/TeleSign.Services.Verify/TeleSign.Services.Verify.csproj
+++ b/src/TeleSign.Services.Verify/TeleSign.Services.Verify.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TeleSign.Services.Verify</RootNamespace>
     <AssemblyName>TeleSign.Services.Verify</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\TeleSign.Services.Verify.XML</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">

--- a/src/TeleSign.Services.Verify/VerifyService.cs
+++ b/src/TeleSign.Services.Verify/VerifyService.cs
@@ -21,14 +21,20 @@ namespace TeleSign.Services.Verify
         private IVerifyResponseParser parser;
 
         /// <summary>
+        /// The alpha
+        /// </summary>
+        private string senderID;
+
+        /// <summary>
         /// Initializes a new instance of the VerifyService class with a supplied credential and URI.
         /// </summary>
         /// <param name="configuration">The configuration information for the service.</param>
-        public VerifyService(TeleSignServiceConfiguration configuration)
+        /// <param name="senderID">The alpha numeric sender ID to be used when sending the verification SMS</param>
+        public VerifyService(TeleSignServiceConfiguration configuration, string senderID = null)
             : this(
                         configuration, 
                         null, 
-                        new JsonDotNetVerifyResponseParser())
+                        new JsonDotNetVerifyResponseParser(), senderID)
         {
         }
 
@@ -43,10 +49,11 @@ namespace TeleSign.Services.Verify
         public VerifyService(
                     TeleSignServiceConfiguration configuration, 
                     IWebRequester webRequester,
-                    IVerifyResponseParser responseParser)
+                    IVerifyResponseParser responseParser, string senderID = null)
             : base(configuration, webRequester)
         {
             this.parser = responseParser;
+            this.senderID = senderID;
         }
 
         /// <summary>
@@ -156,7 +163,7 @@ namespace TeleSign.Services.Verify
                         phoneNumber,
                         verifyCode,
                         messageTemplate,
-                        language);
+                        language, senderID);
 
             try
             {

--- a/src/TeleSign.Services/TeleSign.Services.csproj
+++ b/src/TeleSign.Services/TeleSign.Services.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TeleSign.Services</RootNamespace>
     <AssemblyName>TeleSign.Services</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\TeleSign.Services.XML</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\TeleSign.Services.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">

--- a/src/TeleSign.Services/TeleSignService.cs
+++ b/src/TeleSign.Services/TeleSignService.cs
@@ -52,6 +52,7 @@ namespace TeleSign.Services
                     IWebRequester webRequester,
                     string accountName = "default")
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             this.configuration = (configuration == null)
                         ? TeleSignServiceConfiguration.ReadConfigurationFile(accountName)
                         : configuration;
@@ -224,7 +225,7 @@ namespace TeleSign.Services
 
             HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(fullUri);
             request.Method = method;
-
+            
             string contentType = string.Empty;
             string encodedBody = string.Empty;
             if (method == "POST")

--- a/src/TeleSign.TeleSignCmd/TeleSign.TeleSignCmd.csproj
+++ b/src/TeleSign.TeleSignCmd/TeleSign.TeleSignCmd.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TeleSign.TeleSignCmd</RootNamespace>
     <AssemblyName>TeleSignCmd</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -33,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/TeleSign.TeleSignCmd/app.config
+++ b/src/TeleSign.TeleSignCmd/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
   </startup>
 </configuration>


### PR DESCRIPTION
Telesign requested that the sdk should be updated to restrict requests over tls1.2 exclusively